### PR TITLE
handle new notes format

### DIFF
--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -33,6 +33,18 @@ html.lbh-template > body.lbh-template__body * {
   }
 }
 
+.note-container {
+  .note-header {
+    font-weight: bold;
+  }
+  .note-date {
+    color: #626a6e;
+  }
+  background-color: #f3f3f3;
+  margin-bottom: 20px;
+  padding: 1em;
+}
+
 
 .row-margin-top-s {
   margin-top: 20px !important;

--- a/controllers/help-requests/help_requests.controller.js
+++ b/controllers/help-requests/help_requests.controller.js
@@ -2,7 +2,7 @@
 
 const validator = require('express-validator');
 const querystring = require('querystring');
-
+const notesHelper = require('../../helpers/notes');
 const HelpRequestsService = require('../../services/help-requests/help_requests.service');
 const { mapFieldErrors, mapDescriptionHtml } = require('../../helpers/fieldErrors');
 
@@ -182,7 +182,7 @@ module.exports = {
                 await HelpRequestsService.getHelpRequest(req.params.id)
                 .then(result => {
                     res.locals.hasupdated = req.query.hasupdated;
-                    if(result.CaseNotes.startsWith('[')){
+                    if(notesHelper.isJSON(result.CaseNotes)){
                         result.jsonCaseNotes = JSON.parse(result.CaseNotes)
                     }
                     res.render('help-requests/help-request-edit.njk', {query: result, hasupdated: req.query.hasupdated});

--- a/controllers/help-requests/help_requests.controller.js
+++ b/controllers/help-requests/help_requests.controller.js
@@ -182,6 +182,9 @@ module.exports = {
                 await HelpRequestsService.getHelpRequest(req.params.id)
                 .then(result => {
                     res.locals.hasupdated = req.query.hasupdated;
+                    if(result.CaseNotes.startsWith('[')){
+                        result.jsonCaseNotes = JSON.parse(result.CaseNotes)
+                    }
                     res.render('help-requests/help-request-edit.njk', {query: result, hasupdated: req.query.hasupdated});
                 })
             }

--- a/helpers/notes.js
+++ b/helpers/notes.js
@@ -1,10 +1,22 @@
+
+// https://github.com/douglascrockford/JSON-js/blob/master/json2.js
+const isJSON = (text) => {
+    if (/^[\],:{}\s]*$/.test(text.replace(/\\["\\\/bfnrtu]/g, '@').
+    replace(/"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g, ']').
+    replace(/(?:^|:|,)(?:\s*\[)+/g, ''))) {
+        return true
+    }
+    return false
+}
+
+
 const appendNote = (author, newNote, noteHistory, ) => {
     const noteDate = new Date().toGMTString();
     let updatedNotes = noteHistory;
 
     if(newNote && newNote.trim().length) {
 
-        if(noteHistory.length > 0 && noteHistory.startsWith('[')){
+        if(isJSON(noteHistory)){
             // handle json (new format)
             let newItem = {
                 author: author,
@@ -23,6 +35,7 @@ const appendNote = (author, newNote, noteHistory, ) => {
     return updatedNotes;
 }
 
+
 module.exports = {
-    appendNote
+    appendNote, isJSON
 }

--- a/helpers/notes.js
+++ b/helpers/notes.js
@@ -1,11 +1,23 @@
 const appendNote = (author, newNote, noteHistory, ) => {
     const noteDate = new Date().toGMTString();
-    let updatedNotes = "";
+    let updatedNotes = noteHistory;
 
     if(newNote && newNote.trim().length) {
-        updatedNotes = author + " : " + noteDate + "\n------------\n" + newNote + "\n------\n\n\n" + noteHistory;
-    } else {
-        updatedNotes = noteHistory;
+
+        if(noteHistory.length > 0 && noteHistory.startsWith('[')){
+            // handle json (new format)
+            let newItem = {
+                author: author,
+                noteDate: noteDate,
+                note: newNote
+            }
+            let jsonNoteHistory = JSON.parse(noteHistory) || []
+            jsonNoteHistory.push(newItem)
+            updatedNotes = JSON.stringify(jsonNoteHistory)
+        } else {
+            // handle text (old format)
+            updatedNotes = author + " : " + noteDate + "\n------------\n" + newNote + "\n------\n\n\n" + noteHistory;
+        }
     }
 
     return updatedNotes;

--- a/public/app.css
+++ b/public/app.css
@@ -4217,6 +4217,15 @@ html.lbh-template > body.lbh-template__body * {
   .js-enabled #address-lookup-fieldset {
     display: block; }
 
+.note-container {
+  background-color: #f3f3f3;
+  margin-bottom: 20px;
+  padding: 1em; }
+  .note-container .note-header {
+    font-weight: bold; }
+  .note-container .note-date {
+    color: #626a6e; }
+
 .row-margin-top-s {
   margin-top: 20px !important; }
 

--- a/services/help-requests/help_requests.service.js
+++ b/services/help-requests/help_requests.service.js
@@ -219,8 +219,8 @@ class HelpRequestsService {
 
             const currentSupport = Array.isArray(query.CurrentSupport) ? query.CurrentSupport.join() : query.CurrentSupport;
 
-            let caseNotes = notesHelper.appendNote(userName, recordCreatedCaseNoteText, '');
-            caseNotes = notesHelper.appendNote(userName, query.NewCaseNote, caseNotes);
+            let caseNotes = notesHelper.appendNote(userName, recordCreatedCaseNoteText, '[]');
+          //  caseNotes = notesHelper.appendNote(userName, query.NewCaseNote, caseNotes);
 
             const createFields = {
                 InitialCallbackCompleted: query.InitialCallbackCompleted == 'yes' && true || false,

--- a/services/help-requests/help_requests.service.js
+++ b/services/help-requests/help_requests.service.js
@@ -220,7 +220,6 @@ class HelpRequestsService {
             const currentSupport = Array.isArray(query.CurrentSupport) ? query.CurrentSupport.join() : query.CurrentSupport;
 
             let caseNotes = notesHelper.appendNote(userName, recordCreatedCaseNoteText, '[]');
-          //  caseNotes = notesHelper.appendNote(userName, query.NewCaseNote, caseNotes);
 
             const createFields = {
                 InitialCallbackCompleted: query.InitialCallbackCompleted == 'yes' && true || false,

--- a/views/food-requests/exceptions-edit.njk
+++ b/views/food-requests/exceptions-edit.njk
@@ -343,11 +343,7 @@
                                 }) }}
                             </div>
                         </div>
-
-                        <h3 class="lbh-heading-h3">Case note history (read only):</h3>
-                        <input type="hidden" name="CaseNotes_{{item.Id}}" id="CaseNotes_{{item.Id}}" value="{{item.CaseNotes}}">
-                        <textarea readonly class="govuk-textarea lbh-textarea" rows="20">{{item.CaseNotes}}
-                        </textarea>
+                        {% include '../partials/case-notes-history.njk' %}
                     </fieldset>
 
                 </div>

--- a/views/food-requests/food-request-edit.njk
+++ b/views/food-requests/food-request-edit.njk
@@ -385,10 +385,8 @@
                 </div>
             </div>
 
-            <h3 class="lbh-heading-h3">Case note history (read only):</h3>
-            <input type="hidden" name="CaseNotes" value="{{query.CaseNotes}}">
-            <textarea readonly class="govuk-textarea lbh-textarea" rows="20">{{query.CaseNotes}}
-            </textarea>
+        {% include '../partials/case-notes-history.njk' %}
+
         </fieldset>
 
         {% include '../partials/food-request-edit-cta-btns.njk' %}

--- a/views/help-requests/help-request-edit.njk
+++ b/views/help-requests/help-request-edit.njk
@@ -533,10 +533,7 @@
             "value": query.NewCaseNote
         }) }}
 
-        <h3 class="lbh-heading-h3">Case note history:</h3>
-        <input type="hidden" name="CaseNotes" value="{{query.CaseNotes}}">
-        <textarea readonly class="govuk-textarea lbh-textarea" rows="15">{{query.CaseNotes}}
-        </textarea>
+        {% include '../partials/case-notes-history.njk' %}
 
         <hr>
 

--- a/views/partials/case-notes-history.njk
+++ b/views/partials/case-notes-history.njk
@@ -1,0 +1,14 @@
+<h3 class="lbh-heading-h3">Case note history:</h3>
+<input type="hidden" name="CaseNotes" value="{{query.CaseNotes}}">
+
+{% if query.jsonCaseNotes %}
+    {% for item in query.jsonCaseNotes %}
+    <div class="note-container">
+    <span class="lbh-body-m note-header">{{item.author}}</span> <span class="lbh-body-m note-date">{{item.noteDate}}</span>
+    <p class="lbh-body-m">{{item.note}}</p>
+    </div>
+    {% endfor %}
+{% else %}
+     <p class="lbh-body-m">{{query.CaseNotes}}</p>
+{% endif %}
+


### PR DESCRIPTION
I came up with an idea to fix the multiple notes on a case. Basically I will preserve the existing notes as is, but for any new record I will store the note as JSON text field which allows me to format it properly and style it as I wish, closer to the new designs like so. Or handle the data more freely, if for example, we wanted to sort by date Ascending / Descending, we could

![image](https://user-images.githubusercontent.com/63246336/91037905-be488180-e601-11ea-94a2-8c45ee1d0255.png)

Older notes will display in the old format