### PR TITLE
Fix UPRN object property name

### DIFF
--- a/app/assets/js/addresses.js
+++ b/app/assets/js/addresses.js
@@ -84,8 +84,7 @@ Addresses.prototype.getAddressData = function(postcode, buildingNumber, page) {
     queryString += "&gazetteer=local";
   }
 
-  queryString +="&format=detailed";
-
+  queryString += "&format=detailed";
 
   xhttp.open("GET", this.API_URL + queryString, true);
   xhttp.setRequestHeader("x-api-key", this.API_KEY);
@@ -108,7 +107,7 @@ Addresses.prototype.processAddresses = function() {
         '" data-postcode="' +
         this.addresses[i].postcode +
         '" data-uprn="' +
-        this.addresses[i].uprn +
+        this.addresses[i].UPRN +
         '" data-gazetteer="' +
         this.addresses[i].gazetteer +
         '" data-ward="' +
@@ -125,8 +124,8 @@ Addresses.prototype.processAddresses = function() {
     if (this.allowManualEntry) {
       innerHTML +=
         '</select><p class="lbh-body-m">Or <a href="" class="lbh-link" id="manual-address-button">enter address manually</a>';
-    };
-    
+    }
+
     var select = document.getElementById("address-div");
     if (select == null) {
       select = document.createElement("div");
@@ -142,7 +141,8 @@ Addresses.prototype.processAddresses = function() {
       .getElementById("address-select")
       .addEventListener("change", this.populateChosenAddress.bind(this));
   } else {
-    var html = '<p class="lbh-body-m">No addresses found, please check your details and try again</p>';
+    var html =
+      '<p class="lbh-body-m">No addresses found, please check your details and try again</p>';
 
     if (this.allowManualEntry) {
       html =


### PR DESCRIPTION
**What?**
Fix how UPRN object property was being set, by changing the name of the property to be the same as what we're expecting from Addresses API. It was previously being accessed as a lowercase (uprn) instead of uppercase (UPRN)

**Why?**
Because UPRN wasn't set correctly after getting the address from Addresses API and records were created with status = 'EXCEPTION' in the backend

**Trello card**
https://trello.com/c/kVO6jgEX/72-prevent-the-records-being-flagged-as-exceptions-matching-uprns-when-the-call-handlers-enter-a-record-and-the-uprn-fields-are-com