### PR TITLE
Change validation for CurrentSupport

### DIFF
--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -175,15 +175,14 @@ const helpRequestEditValidation = [
     .notEmpty(),
   oneOf(
     [
-      check("what_coronavirus_help").notEmpty(),
+      [
+        check("what_coronavirus_help").notEmpty(),
+        check("CurrentSupport").notEmpty()
+      ],
       check("initial_callback_completed").custom(value => value === "no")
     ],
-    "Select that the initial callback has not been completed or select what you need help with."
+    "Select that the initial callback has not been completed or select what you need help with and who is helping you at the moment."
   ),
-  check(
-    "CurrentSupport",
-    "Select who is helping you at the moment."
-  ).notEmpty(),
   check("FirstName", "Enter your first name.").notEmpty(),
   check("LastName", "Enter your last name.").notEmpty(),
   check("DobDay", "Enter a day of birth")


### PR DESCRIPTION
What?
Change the validation to for current support to be conditional based on callback completed value

Why?
Because without callback there might be no support identified

Notes
This is an extra field that was missed in previous PR