### PR TITLE
Remove unneeded validation steps and some default values

### DIFF
--- a/cypress/integration/help_requests/help_request.spec.js
+++ b/cypress/integration/help_requests/help_request.spec.js
@@ -88,6 +88,14 @@ describe("help requests", () => {
       .first()
       .click({});
     cy.get("#initial_callback_completed").check("yes", { force: true });
+    cy.get("#NumberOfChildrenUnder18").check("0", { force: true });
+    cy.get(".govuk-accordion__open-all").click({ force: true });
+    cy.get("#CurrentSupport > .govuk-checkboxes__item > input")
+      .first()
+      .check({ force: true });
+    cy.get("#what_coronavirus_help > .govuk-checkboxes__item > input")
+      .first()
+      .check({ force: true });
     cy.get("#callback_required-2").check("no");
     cy.get("button")
       .contains("Update")

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -111,11 +111,6 @@ const helpRequestCreateValidation = [
     "CallbackRequired",
     "Select if a follow up callback is required."
   ).notEmpty(),
-  check("what_coronavirus_help", "Select what you need help with.").notEmpty(),
-  check(
-    "CurrentSupport",
-    "Select who is helping you at the moment."
-  ).notEmpty(),
   check("FirstName", "Enter your first name.").notEmpty(),
   check("LastName", "Enter your last name.").notEmpty(),
   check("address_first_line", "Enter the first line of the address")
@@ -149,13 +144,6 @@ const helpRequestCreateValidation = [
     .escape()
     .notEmpty(),
   check(
-    "NumberOfChildrenUnder18",
-    "Select the number of children under 18 in your household."
-  )
-    .trim()
-    .escape()
-    .notEmpty(),
-  check(
     "consent_to_share",
     "Select yes if we can share the information in this form with organisations offering help."
   )
@@ -177,11 +165,15 @@ const helpRequestEditValidation = [
     [
       [
         check("what_coronavirus_help").notEmpty(),
-        check("CurrentSupport").notEmpty()
+        check("CurrentSupport").notEmpty(),
+        check("NumberOfChildrenUnder18")
+          .trim()
+          .escape()
+          .notEmpty()
       ],
       check("initial_callback_completed").custom(value => value === "no")
     ],
-    "Select that the initial callback has not been completed or select what you need help with and who is helping you at the moment."
+    "Select that the initial callback has not been completed or select what you need help with, who is helping you at the moment and the number of children under 18 in your household."
   ),
   check("FirstName", "Enter your first name.").notEmpty(),
   check("LastName", "Enter your last name.").notEmpty(),
@@ -200,13 +192,6 @@ const helpRequestEditValidation = [
   check(
     "ContactTelephoneNumber",
     "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192."
-  )
-    .trim()
-    .escape()
-    .notEmpty(),
-  check(
-    "NumberOfChildrenUnder18",
-    "Select the number of children under 18 in your household."
   )
     .trim()
     .escape()

--- a/services/help-requests/help_requests.service.js
+++ b/services/help-requests/help_requests.service.js
@@ -273,37 +273,59 @@ class HelpRequestsService {
         DobYear: query.DobYear,
         GettingInTouchReason: query.GettingInTouchReason || "",
         HelpWithAccessingFood:
-          (query.what_coronavirus_help.includes("accessing food") && true) ||
+          (query.what_coronavirus_help &&
+            query.what_coronavirus_help.includes("accessing food") &&
+            true) ||
           false,
         HelpWithAccessingSupermarketFood:
-          (query.what_coronavirus_help.includes("food via supermarket") &&
+          (query.what_coronavirus_help &&
+            query.what_coronavirus_help.includes("food via supermarket") &&
             true) ||
           false,
         HelpWithCompletingNssForm:
-          (query.what_coronavirus_help.includes("nss form support") && true) ||
+          (query.what_coronavirus_help &&
+            query.what_coronavirus_help.includes("nss form support") &&
+            true) ||
           false,
         HelpWithShieldingGuidance:
-          (query.what_coronavirus_help.includes("shielding guidance") &&
+          (query.what_coronavirus_help &&
+            query.what_coronavirus_help.includes("shielding guidance") &&
             true) ||
           false,
         HelpWithNoNeedsIdentified:
-          (query.what_coronavirus_help.includes("no needs") && true) || false,
+          (query.what_coronavirus_help &&
+            query.what_coronavirus_help.includes("no needs") &&
+            true) ||
+          false,
         HelpWithDebtAndMoney:
-          (query.what_coronavirus_help.includes("debt and money") && true) ||
+          (query.what_coronavirus_help &&
+            query.what_coronavirus_help.includes("debt and money") &&
+            true) ||
           false,
         HelpWithHealth:
-          (query.what_coronavirus_help.includes("health") && true) || false,
+          (query.what_coronavirus_help &&
+            query.what_coronavirus_help.includes("health") &&
+            true) ||
+          false,
         HelpWithMentalHealth:
-          (query.what_coronavirus_help.includes("mental health") && true) ||
+          (query.what_coronavirus_help &&
+            query.what_coronavirus_help.includes("mental health") &&
+            true) ||
           false,
         HelpWithHousing:
-          (query.what_coronavirus_help.includes("housing") && true) || false,
+          (query.what_coronavirus_help &&
+            query.what_coronavirus_help.includes("housing") &&
+            true) ||
+          false,
         HelpWithAccessingInternet:
-          (query.what_coronavirus_help.includes("technology support") &&
+          (query.what_coronavirus_help &&
+            query.what_coronavirus_help.includes("technology support") &&
             true) ||
           false,
         HelpWithSomethingElse:
-          (query.what_coronavirus_help.includes("something else") && true) ||
+          (query.what_coronavirus_help &&
+            query.what_coronavirus_help.includes("something else") &&
+            true) ||
           false,
         CurrentSupport: currentSupport || "",
         CurrentSupportFeedback: query.CurrentSupportFeedback || "",

--- a/views/help-requests/help-request-create.njk
+++ b/views/help-requests/help-request-create.njk
@@ -133,12 +133,8 @@
         
         
         <!-- TODO: These values should not be defaulted but instead should be Optional. It requires API changes. To be fixed -->
-        <input type="hidden" name="what_coronavirus_help" value="something else">
-        <input type="hidden" name="CurrentSupport" value="not sure">
-        <input type="hidden" name="NumberOfChildrenUnder18" value="0">
         <input type="hidden" name="InitialCallbackCompleted" value="false">
         <input type="hidden" name="CallbackRequired" value="true">
-
 
         {{ lbhRadios({
             "fieldset": {


### PR DESCRIPTION
**What?**
Remove validation and default values for `current support`,` help needed` and `number of children under 18` for create help request.
Remove `number of children under 18` validation for edit help request

**Why?**
These fields might not be available during the creation of the help request or if the callback has not been completed.

**Notes**
`number of children under 18` column in the backend seems not nullable, but whenever the records are bulk uploaded rather than created through this UI, the `number of children under 18` gets set to null in the database.

These changes also seem to work okay without changing any backend, but it might need to be considered.


https://trello.com/c/4DtaQb7Y/75-remove-requirement-to-populate-specific-fields-when-updating-a-record-if-intialcallbackcompleted-false