### PR TITLE
Add total call attempts view to callback list

### DIFF
--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -197,3 +197,7 @@ textarea[readonly] {
 label[for="HelpNeeded-3"] {
   margin-right: 18px;
 }
+
+.redText {
+  color: red;
+}

--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -194,6 +194,7 @@ textarea[readonly] {
     transform: rotate(360deg);
   }
 }
+
 label[for="HelpNeeded-3"] {
   margin-right: 18px;
 }

--- a/public/app.css
+++ b/public/app.css
@@ -4210,7 +4210,7 @@ x.\:-moz-any-link {
   margin-bottom: 0; }
 
 html.lbh-template > body.lbh-template__body * {
-  font-family: 'Open Sans', sans-serif; }
+  font-family: "Open Sans", sans-serif; }
 
 #address-lookup-fieldset {
   display: none; }
@@ -4305,7 +4305,7 @@ textarea[readonly] {
   opacity: 0;
   z-index: -1; }
   .is-loading #loader_overlay {
-    opacity: .85;
+    opacity: 0.85;
     z-index: 100; }
 
 #loader_spinner {
@@ -4336,3 +4336,9 @@ textarea[readonly] {
     transform: rotate(0deg); }
   100% {
     transform: rotate(360deg); } }
+
+label[for="HelpNeeded-3"] {
+  margin-right: 18px; }
+
+.redText {
+  color: red; }

--- a/views/partials/help-request-data-list.njk
+++ b/views/partials/help-request-data-list.njk
@@ -6,6 +6,7 @@
         <th scope="col" class="govuk-table__header">Address</th>
         <th scope="col" class="govuk-table__header">Requested Date</th>
         <th scope="col" class="govuk-table__header">Type</th>
+        <th scope="col" class="govuk-table__header">Unsuccessful call attempts</th>
         <th scope="col" class="govuk-table__header"></th>
         </tr>
     </thead>
@@ -20,6 +21,15 @@
                 </td>
                 <td class="govuk-table__cell">{{item.creation_date}}</td>
                 <td class="govuk-table__cell">{{item.HelpNeeded}}</td>
+                <span hidden=true>{% set unsuccessfulCalls = [] %}
+                {% for call in item.HelpRequestCalls %}
+                    {%if call.CallOutcome.includes('no_answer_machine') or call.CallOutcome.includes('wrong_number') or call.CallOutcome.includes('voicemail') %}
+                        {{ unsuccessfulCalls.push(call) }}
+                    {% endif %}
+                {% endfor %}
+                </span>
+                {% set redText = "redText" if unsuccessfulCalls|length>4 %}
+                <td class="govuk-table__cell {{redText}}">{{unsuccessfulCalls|length}}</td>
                 <td class="govuk-table__cell">
                     <a data-testid="view-button"  href="/help-requests/edit/{{item.Id}}" class="js-cta-btn" id="view-resident-{{item.Id}}">View</a>
                 </td>


### PR DESCRIPTION
Display the number of unsuccessful call attempts in callbacks list.
If number of unsuccessful call attempts is more than or equal to 5, the number displays in red.
Call is unsuccessful if: Number is wrong, there's no answering machine, or a voicemail is left

<img width="519" alt="image" src="https://user-images.githubusercontent.com/54268893/100376636-c8668b80-3007-11eb-8f0c-27a095996561.png">

Notes:
Linting in app.scss, the only relevant lines in that file are 198, 199