### PR TITLE
Add Contact Tracing Help Type

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,7 +37,7 @@ const addResident = resident => {
   cy.get("#address-div").should("contain", "Select address");
   cy.get("#address-select").select("0", { force: true });
   cy.get("#consent_to_share").check("yes", { force: true });
-  cy.get("#HelpNeeded").check("Help Request", { force: true });
+  cy.get("#HelpNeeded-2").check("Help Request", { force: true });
   cy.get("button")
     .contains("Next")
     .click({ force: true });

--- a/views/help-requests/help-request-create.njk
+++ b/views/help-requests/help-request-create.njk
@@ -178,6 +178,11 @@
             "classes": "govuk-radios--inline",
             "items": [
                 {
+                "value": "Contact Tracing",
+                "text": "Contact Tracing",
+                "checked": true if query.HelpNeeded and "Contact Tracing" in query.HelpNeeded else false
+                },
+                {
                 "value": "Help Request",
                 "text": "Help Request",
                 "checked": true if query.HelpNeeded and "Help Request" in query.HelpNeeded else false

--- a/views/help-requests/help-request-edit.njk
+++ b/views/help-requests/help-request-edit.njk
@@ -115,6 +115,11 @@
                     "classes": "govuk-radios--inline",
                     "items": [
                         {
+                        "value": "Contact Tracing",
+                        "text": "Contact Tracing",
+                        "checked": true if query.HelpNeeded and "Contact Tracing" in query.HelpNeeded else false
+                        },
+                        {
                         "value": "Help Request",
                         "text": "Help Request",
                         "checked": true if query.HelpNeeded and "Help Request" in query.HelpNeeded else false

--- a/views/help-requests/help-requests-callbacks-list.njk
+++ b/views/help-requests/help-requests-callbacks-list.njk
@@ -19,14 +19,11 @@
         <div class="govuk-grid-column-one-quarter">
             <a href="/help-requests/callbacks" class="lbh-link">Show All</a>
         </div>
-        <div class="govuk-grid-column-one-quarter">
-            <a href="/help-requests/callbacks?HelpNeeded=Help%20Request" class="lbh-link">Help Request</a>
-        </div>
-        <div class="govuk-grid-column-one-quarter">
-            <a href="/help-requests/callbacks?HelpNeeded=Shielding" class="lbh-link">Shielding</a>
-        </div>
-        <div class="govuk-grid-column-one-quarter">
-            <a href="/help-requests/callbacks?HelpNeeded=Welfare%20Call" class="lbh-link">Welfare Call</a>
+        <div class="govuk-grid-column-three-quarters">
+            <a href="/help-requests/callbacks?HelpNeeded=Contact%20Tracing" class="lbh-link">Contact Tracing</a>&nbsp;
+            <a href="/help-requests/callbacks?HelpNeeded=Help%20Request" class="lbh-link">Help Request</a>&nbsp;
+            <a href="/help-requests/callbacks?HelpNeeded=Shielding" class="lbh-link">Shielding</a>&nbsp;
+            <a href="/help-requests/callbacks?HelpNeeded=Welfare%20Call" class="lbh-link">Welfare Call</a>&nbsp;
         </div>
     </div>
 


### PR DESCRIPTION
# Screenshots

![image](https://user-images.githubusercontent.com/2429225/100446401-a4a65280-30a6-11eb-80c6-ccb41b862c9f.png)
![image](https://user-images.githubusercontent.com/2429225/100446577-f51db000-30a6-11eb-8a07-ab534699b5a0.png)
![image](https://user-images.githubusercontent.com/2429225/100446589-fbac2780-30a6-11eb-997a-7f730b822f5e.png)


# What

Add Contact Tracing as a help type on the help request, and allow call handlers to be able to fitler based on this call type.

# Why

Call handlers want to use HTH to drive outbound calls, and capture notes on one tool.

# Link

https://trello.com/c/3CbuUpw5/96-list-as-a-contact-tracing-call-handler-i-can-see-a-filtered-view-of-contact-tracing-callbacks-that-need-to-be-made