### PR TITLE
Added a NHS Contact tracing number field to Edit view

### DIFF
--- a/views/help-requests/help-request-edit.njk
+++ b/views/help-requests/help-request-edit.njk
@@ -78,6 +78,14 @@
                 </p>
             </div>
         </div>
+
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <p class="lbh-body-m">
+                    {%if query.HelpNeeded === "Contact Tracing" %}<strong>Contact tracing ID: </strong> {{ query.NhsCtasId }} <br />{%endif%}
+                </p>
+            </div>
+        </div>
        
         <span hidden=true>
         {% set voicemails = 0 %}

--- a/views/help-requests/help-request-edit.njk
+++ b/views/help-requests/help-request-edit.njk
@@ -83,6 +83,8 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 <p class="lbh-body-m">
+                    <strong>Contact tracing ID: </strong> 
+                    {%if query.NhsCtasId %} {{ query.NhsCtasId  }} {%else%} not found {%endif%}
                 </p>
             </div>
         </div>

--- a/views/help-requests/help-request-edit.njk
+++ b/views/help-requests/help-request-edit.njk
@@ -79,13 +79,14 @@
             </div>
         </div>
 
+        {%if query.HelpNeeded === "Contact Tracing" %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 <p class="lbh-body-m">
-                    {%if query.HelpNeeded === "Contact Tracing" %}<strong>Contact tracing ID: </strong> {{ query.NhsCtasId }} <br />{%endif%}
                 </p>
             </div>
         </div>
+        {%endif%}
        
         <span hidden=true>
         {% set voicemails = 0 %}


### PR DESCRIPTION
# What:
 - A NHS Contract Tracing number field in the edit view
 - Its conditional display based on "help needed" type - displayed if type is "Contact Tracing".

# Why:
 - So that call handlers wouldn't need to flip between tabs to get that number.
   Convenience of identifying a person by NHS CTas number within this (I need help) tool

# Screenshot:
![image](https://user-images.githubusercontent.com/43747286/100873905-b53a3c80-349b-11eb-928c-a81e053e239b.png)

# Link to Trello:
https://trello.com/c/PBmmLNBl/118-as-a-outbound-call-handler-when-i-view-a-help-request-then-i-can-see-the-nhs-test-and-trace-ctas-number-numbers

# Notes:
Co-Authored-By: kosiakkatrina <54268893+kosiakkatrina@users.noreply.github.com>