### PR TITLE
Update so that initial callbacks are set to correct value

### DIFF
--- a/controllers/help-requests/help_requests.controller.js
+++ b/controllers/help-requests/help_requests.controller.js
@@ -475,8 +475,8 @@ module.exports = {
             // keep the original record and update only case notes and callback
             let updateRequest = originalRecord;
             updateRequest.NewCaseNote = query.NewCaseNote;
-            updateRequest.callback_required = query.callback_required;
-            updateRequest.initial_callback_completed = "yes";
+            updateRequest.initialCallBack = query.InitialCallbackCompleted == 'true' ? true : false;
+            updateRequest.callbackRequired = query.callback_required == "no" ? false : true;
             handleUpdate(req, res, updateRequest, userName);
           }
         );

--- a/services/help-requests/help_requests.service.js
+++ b/services/help-requests/help_requests.service.js
@@ -74,8 +74,6 @@ class HelpRequestsService {
         data = result.data;
 
         // Create new keys with yes/no values based on boolean input values
-        data.initial_callback_completed =
-          data.InitialCallbackCompleted === true ? "yes" : "no";
         data.callback_required = data.CallbackRequired === true ? "yes" : "no";
         data.consent_to_share = data.ConsentToShare === true ? "yes" : "no";
 
@@ -153,18 +151,8 @@ class HelpRequestsService {
           callbackRequired = true
         }
       }
-      else if(query.initialCallBack == "yes"){
-        query.initialCallBack = true
-      }
-      else if(query.initialCallBack == "no"){
-        query.initialCallBack = false
-      }
-      else if(query.callbackRequired == "yes"){
-        query.callbackRequired = true
-      }
-      else if(query.callbackRequired == "no"){
-        query.callbackRequired = false
-      }
+
+
       const updatedFields = {
         InitialCallbackCompleted:initialCallBack,
         HelpNeeded: query.HelpNeeded || "",

--- a/services/help-requests/help_requests.service.js
+++ b/services/help-requests/help_requests.service.js
@@ -151,6 +151,18 @@ class HelpRequestsService {
         initialCallBack = true
         callbackRequired = true
       }
+      else if(query.initialCallBack == "yes"){
+        query.initialCallBack = true
+      }
+      else if(query.initialCallBack == "no"){
+        query.initialCallBack = false
+      }
+      else if(query.callbackRequired == "yes"){
+        query.callbackRequired = true
+      }
+      else if(query.callbackRequired == "no"){
+        query.callbackRequired = false
+      }
       const updatedFields = {
         InitialCallbackCompleted:initialCallBack,
         HelpNeeded: query.HelpNeeded || "",


### PR DESCRIPTION
**What**
- When initial callbacks and callback required are set to yes or no then they should be handled in the update

**Why**
- This was removed with the old updates, however was still being set like this if a resident was added and a callback complete at the same time (probably because its an inbound call)- this takes you to the call complete page which sets them to yes and no. This was not being handled in the update function