### PR TITLE
Fix validation for editing a help request

### DIFF
--- a/cypress/FakeHelpRequestApi.js
+++ b/cypress/FakeHelpRequestApi.js
@@ -26,9 +26,6 @@ app.post("/help-requests", (req, res) => {
   console.log("Saving resident: ", resident.Id);
   res.status(200).send(resident);
 });
-app.post("/help-requests/:id/calls", (req, res) => {
-  res.status(200);
-});
 app.get("/help-requests", (req, res) => {
   const postcode = req.query.postcode;
   console.log("Filter resident by Postcode: ", postcode);

--- a/cypress/integration/help_requests/view_residents_to_contact.spec.js
+++ b/cypress/integration/help_requests/view_residents_to_contact.spec.js
@@ -28,8 +28,6 @@ describe("view residents to contact", () => {
       .first()
       .click();
 
-    cy.get("#CallDetail").click({ force: true });
-    cy.get("#CallOutcome").click({ force: true });
     // open accordion
     cy.get("#resident-bio-heading")
       .click({
@@ -47,6 +45,7 @@ describe("view residents to contact", () => {
     cy.get("#default-example-heading-1").click({ force: true });
     cy.get("#CurrentSupport").click({ force: true });
     cy.get("#update-btn").click({ force: true });
+    cy.url().should("include", "/help-requests");
   });
 
   it("allow you to change address", () => {

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -144,86 +144,25 @@ const helpRequestEditValidation = [
   oneOf(
     [
       [
-        check("what_coronavirus_help").notEmpty(),
-        check("CurrentSupport").notEmpty(),
-        check("NumberOfChildrenUnder18").trim().escape().notEmpty(),
-        check("HelpNeeded").custom(
-          (value) =>
-            value === "Help Request" ||
-            value === "Welfare Call" ||
-            value === "Shielding" ||
-            value === "Contact Tracing"
-        ),
+        check("CallMade")
+          .trim()
+          .escape()
+          .custom(value => value === "no")
       ],
+      [check("CallMade").isEmpty()],
       [
-        check("CallOutcome").custom(
-          (value) =>
-            value.includes("voicemail") ||
-            value.includes("no_answer_machine") ||
-            value.includes("wrong_number") ||
-            value.includes("close_case")
-        ),
-        check("CallType", "specify the type of help the call was regarding")
+        check("CallOutcome").notEmpty(),
+        check("CallType")
           .trim()
           .escape()
           .notEmpty(),
-        check("CallDirection", "specify who initiated the call")
+        check("CallDirection")
           .trim()
           .escape()
-          .notEmpty(),
-      ],
-      [
-        check("CallOutcome").custom(
-          (value) =>
-            value === "refused_to_engage" ||
-            value === "call_rescheduled" ||
-            value === "voicemail" ||
-            value === "no_answer_machine" ||
-            value === "wrong_number"
-        ),
-        check("CallType", "specify the type of help the call was regarding")
-          .trim()
-          .escape()
-          .notEmpty(),
-        check("CallDirection", "specify who initiated the call")
-          .trim()
-          .escape()
-          .notEmpty(),
-      ],
-      [
-        check("CallOutcome").custom(
-          (value) =>
-            value === "callback_complete" ||
-            value === "refused_to_engage" ||
-            value === "follow_up_requested" ||
-            value === "call_rescheduled"
-        ),
-        check("CallType", "specify the type of help the call was regarding")
-          .trim()
-          .escape()
-          .notEmpty(),
-        check("CallDirection", "specify who initiated the call")
-          .trim()
-          .escape()
-          .notEmpty(),
-      ],
-      [
-        check("CallOutcome").custom(
-          (value) =>
-            value.includes("callback_complete") ||
-            value.includes("follow_up_requested")
-        ),
-        check("CallType", "specify the type of help the call was regarding")
-          .trim()
-          .escape()
-          .notEmpty(),
-        check("CallDirection", "specify who initiated the call")
-          .trim()
-          .escape()
-          .notEmpty(),
-      ],
+          .notEmpty()
+      ]
     ],
-    "Select what you need help with, who is helping you at the moment and the number of children under 18 in your household. If you have logged a call, make sure you have completed all the neccessary fields"
+    "Specify the type of help the call was regarding, who initiated the call and the outcome of the call."
   ),
   check("FirstName", "Enter your first name.").notEmpty(),
   check("LastName", "Enter your last name.").notEmpty(),

--- a/services/help-requests/help_requests.service.js
+++ b/services/help-requests/help_requests.service.js
@@ -143,12 +143,15 @@ class HelpRequestsService {
       let initialCallBack = query.initialCallBack
       let callbackRequired = query.callbackRequired
 
-      if(query.CallOutcome == "callback_complete" || query.CallOutcome == "refused_to_engage" || query.CallOutcome == "close_case"){
-        initialCallBack = true
-        callbackRequired = false
-      }else if(Array.isArray(query.CallOutcome) && query.CallOutcome.length == 2 && query.CallOutcome.includes("follow_up_requested") &&  query.CallOutcome.includes("callback_complete")){
-        initialCallBack = true
-        callbackRequired = true
+      if (query.CallOutcome) {
+        if(query.CallOutcome == "callback_complete" || query.CallOutcome == "refused_to_engage" || query.CallOutcome == "close_case"){
+          initialCallBack = true
+          callbackRequired = false
+        }
+        else if(query.CallOutcome.includes("follow_up_requested") || query.CallOutcome.includes("call_rescheduled")){
+          initialCallBack = true
+          callbackRequired = true
+        }
       }
       const updatedFields = {
         InitialCallbackCompleted:initialCallBack,


### PR DESCRIPTION
Remove the validation for `help needed`, `support network` and `kids under 18` entirely.
For the calls, if the call agent selected `no` or didn't select anything for `did you make a call?` question, that will not throw any errors and will update the record. If they selected `yes`, it will throw this error unless they finish all the required sub-fields in the call form

![image](https://user-images.githubusercontent.com/54268893/100995587-e4aa8100-354f-11eb-9155-5f7469ded2a5.png)

Allows to update a help request without logging a call, part of fixing https://trello.com/c/dWemuS63/127-case-notes-not-saving
Fixes follow up calls falling off the callbacks list
