### PR TITLE
Conditionally display fields if they exist

### DIFF
--- a/views/help-requests/help-request-edit.njk
+++ b/views/help-requests/help-request-edit.njk
@@ -65,7 +65,9 @@
                     {%if query.AddressSecondLine %}{{query.AddressSecondLine}} <br />{%endif%}
                     {%if query.AddressThirdLine %}{{query.AddressThirdLine}} <br />{%endif%}
                     {%if query.PostCode %}{{query.PostCode}} <br />{%endif%}
-                    {%if query.Ward %}{{query.Ward}}{%endif%}
+                    {%if query.Ward %}{{query.Ward}}{%endif%} 
+                    {%if not query.AddressFirstLine and not query.AddressSecondLine and not query.AddressThirdLine and not query.PostCode %}
+                     This resident has not provided their address{%endif%}
                 </p>
                 <a id="change-address" href="/help-requests/address/{{query.Id}}" class="lbh-link">Change address</a>
             </div>

--- a/views/help-requests/help-request-edit.njk
+++ b/views/help-requests/help-request-edit.njk
@@ -61,11 +61,11 @@
             <div class="govuk-grid-column-full">
                 <p class="lbh-body-m">
                     <strong>Address</strong><br />
-                    {{query.AddressFirstLine}} <br />
-                    {{query.AddressSecondLine}} <br />
-                    {{query.AddressThirdLine}} <br />
-                    {{query.PostCode}} <br />
-                    {{query.Ward}}
+                    {%if query.AddressFirstLine %}{{query.AddressFirstLine}} <br />{%endif%}
+                    {%if query.AddressSecondLine %}{{query.AddressSecondLine}} <br />{%endif%}
+                    {%if query.AddressThirdLine %}{{query.AddressThirdLine}} <br />{%endif%}
+                    {%if query.PostCode %}{{query.PostCode}} <br />{%endif%}
+                    {%if query.Ward %}{{query.Ward}}{%endif%}
                 </p>
                 <a id="change-address" href="/help-requests/address/{{query.Id}}" class="lbh-link">Change address</a>
             </div>
@@ -73,7 +73,7 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 <p class="lbh-body-m">
-                    <strong>Contact telephone: </strong> {{ query.ContactTelephoneNumber}} <br />
+                    {%if query.ContactTelephoneNumber %}<strong>Contact telephone: </strong> {{ query.ContactTelephoneNumber}} <br />{%endif%}
                     {%if query.ContactMobileNumber %}<strong>Contact mobile: </strong> {{ query.ContactMobileNumber}}{%endif%}
                 </p>
             </div>


### PR DESCRIPTION
**What**
- Only display address fields and contact number if they exist

**Why**
-  As test and trace records are imported, sometimes these fields do not exist so we dont have a creation flow/validation that sets them to default values 


Co-authored-by: duslerke liudvikast@gmail.com