### PR TITLE
Edit/follow up required and call count display changes

### DIFF
--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -214,3 +214,7 @@ label[for="HelpNeeded-3"] {
 .redText {
   color: red;
 }
+
+.table-cell-text-centered {
+  text-align: center;
+}

--- a/public/app.css
+++ b/public/app.css
@@ -4351,3 +4351,6 @@ label[for="HelpNeeded-3"] {
 
 .redText {
   color: red; }
+
+.table-cell-text-centered {
+  text-align: center; }

--- a/views/help-requests/help-request-edit.njk
+++ b/views/help-requests/help-request-edit.njk
@@ -125,7 +125,7 @@
                     <strong>Current call request status</strong><br />
                     Initial requested date: {{query.creation_date}} <br />
                     {%if followup %}
-                        Follow up requested date: {{followupRequestedDates|first}} <br />
+                        Follow up required: Y <br />
                     {% endif %}
                     Unsuccessful call attempts: {{unsuccessfulCalls}} <br />
                     Voicemails left: {{voicemails}} <br />

--- a/views/help-requests/help-request-edit.njk
+++ b/views/help-requests/help-request-edit.njk
@@ -92,8 +92,6 @@
        
         <span hidden=true>
         {% set voicemails = 0 %}
-        {% set totalVoicemails = 0 %}
-        {% set totalUnsuccessfulCalls = 0 %}
         {% set unsuccessfulCalls = 0 %}
         {% set successfulCalls = 0 %}
         {% set followup = false %}        
@@ -112,7 +110,6 @@
                         {%if not stopCount %}
                             {% set unsuccessfulCalls = unsuccessfulCalls + 1 %}
                         {% endif %}
-                        {% set totalUnsuccessfulCalls = totalUnsuccessfulCalls + 1 %}
                     {% endif %}
                     {%if (not call.CallOutcome.includes('no_answer_machine') and not call.CallOutcome.includes('wrong_number') and not call.CallOutcome.includes('voicemail')) and not stopCount %}
                         {% set successfulCalls = successfulCalls + 1 %}
@@ -121,22 +118,11 @@
                         {%if not stopCount %}
                             {% set voicemails = voicemails + 1 %}
                         {% endif %}
-                        {% set totalVoicemails = totalVoicemails + 1 %}
                     {% endif %}
                 {% endfor %}
         {% set lastCall = query.HelpRequestCalls|first  %}
         {% endif %}
         </span>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-half">
-                <p class="lbh-body-m">
-                    <strong>Total call status</strong><br />
-                    Total calls with resident: {{query.HelpRequestCalls|length - totalUnsuccessfulCalls}} <br />
-                    Total unsuccessful call attempts: {{totalUnsuccessfulCalls}} <br />
-                    Total voicemails left: {{totalVoicemails}} 
-                </p>
-            </div>
-        </div>
          <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-half">
                 <p class="lbh-body-m">

--- a/views/help-requests/help-request-edit.njk
+++ b/views/help-requests/help-request-edit.njk
@@ -123,7 +123,7 @@
             <div class="govuk-grid-column-one-half">
                 <p class="lbh-body-m">
                     <strong>Current call request status</strong><br />
-                    Initial requested date: {{query.creation_date}} <br />
+                    Latest call request date: {{query.creation_date}} <br />
                     {%if followup %}
                         Follow up required: Y <br />
                     {% endif %}

--- a/views/help-requests/help-request-edit.njk
+++ b/views/help-requests/help-request-edit.njk
@@ -93,15 +93,9 @@
         <span hidden=true>
         {% set voicemails = 0 %}
         {% set unsuccessfulCalls = 0 %}
-        {% set followup = false %}        
         {% set stopCount = false %}
-        {% set followupRequestedDates =[] %}
         {% if query.HelpRequestCalls %}
                 {% for call in query.HelpRequestCalls %}
-                    {%if call.CallOutcome.includes('follow_up_requested') %}
-                        {% set followup=true %}
-                        {{  followupRequestedDates.push(call.creation_date) }}
-                    {% endif %}
                     {%if call.CallOutcome.includes('callback_complete') or call.CallOutcome.includes('refused_to_engage') %}
                         {% set stopCount=true %}
                     {% endif %}
@@ -124,7 +118,7 @@
                 <p class="lbh-body-m">
                     <strong>Current call request status</strong><br />
                     Latest call request date: {{query.creation_date}} <br />
-                    {%if followup %}
+                    {%if query.CallbackRequired %}
                         Follow up required: Y <br />
                     {% endif %}
                     Unsuccessful call attempts: {{unsuccessfulCalls}} <br />

--- a/views/help-requests/help-request-edit.njk
+++ b/views/help-requests/help-request-edit.njk
@@ -93,7 +93,6 @@
         <span hidden=true>
         {% set voicemails = 0 %}
         {% set unsuccessfulCalls = 0 %}
-        {% set successfulCalls = 0 %}
         {% set followup = false %}        
         {% set stopCount = false %}
         {% set followupRequestedDates =[] %}
@@ -110,9 +109,6 @@
                         {%if not stopCount %}
                             {% set unsuccessfulCalls = unsuccessfulCalls + 1 %}
                         {% endif %}
-                    {% endif %}
-                    {%if (not call.CallOutcome.includes('no_answer_machine') and not call.CallOutcome.includes('wrong_number') and not call.CallOutcome.includes('voicemail')) and not stopCount %}
-                        {% set successfulCalls = successfulCalls + 1 %}
                     {% endif %}
                     {%if call.CallOutcome.includes('voicemail') %}
                         {%if not stopCount %}
@@ -131,7 +127,6 @@
                     {%if followup %}
                         Follow up requested date: {{followupRequestedDates|first}} <br />
                     {% endif %}
-                    Calls with resident: {{successfulCalls}} <br />
                     Unsuccessful call attempts: {{unsuccessfulCalls}} <br />
                     Voicemails left: {{voicemails}} <br />
                     {%if lastCall and lastCall.CallOutcome.includes('call_rescheduled') %}

--- a/views/partials/help-request-data-list.njk
+++ b/views/partials/help-request-data-list.njk
@@ -37,17 +37,8 @@
                 </span>
                 {% set redText = "redText" if unsuccessfulCalls>4 %}
                 <td style="text-align:center" class="govuk-table__cell {{redText}}">{{unsuccessfulCalls}}</td>
-                
 
-                <span hidden=true>
-                {% set followUpRequired = false %}
-                {% for call in item.calls %}
-                    {% if call.CallOutcome.includes('follow_up_requested') %}
-                        {% set followUpRequired = true %}
-                    {% endif %}
-                {% endfor %}
-                </span>
-                <td style="text-align:center" class="govuk-table__cell">{% if followUpRequired %}Y{% endif %}</td>
+                <td style="text-align:center" class="govuk-table__cell">{% if item.CallbackRequired %}Y{% endif %}</td>
                 <td class="govuk-table__cell">
                     <a data-testid="view-button"  href="/help-requests/edit/{{item.Id}}" class="js-cta-btn" id="view-resident-{{item.Id}}">View</a>
                 </td>

--- a/views/partials/help-request-data-list.njk
+++ b/views/partials/help-request-data-list.njk
@@ -6,8 +6,8 @@
         <th scope="col" class="govuk-table__header">Address</th>
         <th scope="col" class="govuk-table__header">Requested Date</th>
         <th scope="col" class="govuk-table__header">Type</th>
-        <th scope="col" class="govuk-table__header">Unsuccessful call attempts</th>
-        <th scope="col" class="govuk-table__header">Follow-up required?</th>
+        <th scope="col" style="text-align:center" class="govuk-table__header">Unsuccessful call attempts</th>
+        <th scope="col" style="text-align:center" class="govuk-table__header">Follow-up required?</th>
         <th scope="col" class="govuk-table__header"></th>
         </tr>
     </thead>
@@ -47,7 +47,7 @@
                     {% endif %}
                 {% endfor %}
                 </span>
-                <td class="govuk-table__cell">{% if followUpRequired %}Y{% endif %}</td>
+                <td style="text-align:center" class="govuk-table__cell">{% if followUpRequired %}Y{% endif %}</td>
                 <td class="govuk-table__cell">
                     <a data-testid="view-button"  href="/help-requests/edit/{{item.Id}}" class="js-cta-btn" id="view-resident-{{item.Id}}">View</a>
                 </td>

--- a/views/partials/help-request-data-list.njk
+++ b/views/partials/help-request-data-list.njk
@@ -7,6 +7,7 @@
         <th scope="col" class="govuk-table__header">Requested Date</th>
         <th scope="col" class="govuk-table__header">Type</th>
         <th scope="col" class="govuk-table__header">Unsuccessful call attempts</th>
+        <th scope="col" class="govuk-table__header">Follow-up required?</th>
         <th scope="col" class="govuk-table__header"></th>
         </tr>
     </thead>
@@ -36,6 +37,17 @@
                 </span>
                 {% set redText = "redText" if unsuccessfulCalls>4 %}
                 <td class="govuk-table__cell {{redText}}">{{unsuccessfulCalls}}</td>
+                
+
+                <span hidden=true>
+                {% set followUpRequired = false %}
+                {% for call in item.calls %}
+                    {% if call.CallOutcome.includes('follow_up_requested') %}
+                        {% set followUpRequired = true %}
+                    {% endif %}
+                {% endfor %}
+                </span>
+                <td class="govuk-table__cell">{% if followUpRequired %}Y{% endif %}</td>
                 <td class="govuk-table__cell">
                     <a data-testid="view-button"  href="/help-requests/edit/{{item.Id}}" class="js-cta-btn" id="view-resident-{{item.Id}}">View</a>
                 </td>

--- a/views/partials/help-request-data-list.njk
+++ b/views/partials/help-request-data-list.njk
@@ -36,7 +36,7 @@
                 {% endfor %}
                 </span>
                 {% set redText = "redText" if unsuccessfulCalls>4 %}
-                <td class="govuk-table__cell {{redText}}">{{unsuccessfulCalls}}</td>
+                <td style="text-align:center" class="govuk-table__cell {{redText}}">{{unsuccessfulCalls}}</td>
                 
 
                 <span hidden=true>

--- a/views/partials/help-request-data-list.njk
+++ b/views/partials/help-request-data-list.njk
@@ -6,8 +6,8 @@
         <th scope="col" class="govuk-table__header">Address</th>
         <th scope="col" class="govuk-table__header">Requested Date</th>
         <th scope="col" class="govuk-table__header">Type</th>
-        <th scope="col" style="text-align:center" class="govuk-table__header">Unsuccessful call attempts</th>
-        <th scope="col" style="text-align:center" class="govuk-table__header">Follow-up required?</th>
+        <th scope="col" class="table-cell-text-centered govuk-table__header">Unsuccessful call attempts</th>
+        <th scope="col" class="table-cell-text-centered govuk-table__header">Follow-up required?</th>
         <th scope="col" class="govuk-table__header"></th>
         </tr>
     </thead>
@@ -36,9 +36,9 @@
                 {% endfor %}
                 </span>
                 {% set redText = "redText" if unsuccessfulCalls>4 %}
-                <td style="text-align:center" class="govuk-table__cell {{redText}}">{{unsuccessfulCalls}}</td>
+                <td class="table-cell-text-centered govuk-table__cell {{redText}}">{{unsuccessfulCalls}}</td>
 
-                <td style="text-align:center" class="govuk-table__cell">{% if item.CallbackRequired %}Y{% endif %}</td>
+                <td class="table-cell-text-centered govuk-table__cell">{% if item.CallbackRequired %}Y{% endif %}</td>
                 <td class="govuk-table__cell">
                     <a data-testid="view-button"  href="/help-requests/edit/{{item.Id}}" class="js-cta-btn" id="view-resident-{{item.Id}}">View</a>
                 </td>


### PR DESCRIPTION
# What:
- Added "Follow-up required?" column to the "Calls list" page.
- Removed "Total call status" information block from the edit view.
- Removed "Calls with resident" field from the remaining calls information block.
- Replaced "Follow up requested date" with "Follow up required: Y" in the remaining calls information block.
- Renamed "Initial requested date" field into "Latest call request date" in the remaining calls information block.
- Centered "Unsuccessful call attempts" table head as well as the values.
- Centered "Follow-up required" table head as well as the values.

# Why:
- "Total call status" was considered Non-essential.
- "Follow up requested date' is not needed as a follow up doesn't necessarily refer to a call.
- Reasons behind the other changes were not specified, but might be linked to decluttering and making easier to read the interface.

# Screenshots:
**Callbacks list:**
![image](https://user-images.githubusercontent.com/43747286/101516634-9f36eb00-3977-11eb-9fb9-0b41c1cd76ae.png)
**Help request edit view:**
![image](https://user-images.githubusercontent.com/43747286/101516927-02288200-3978-11eb-89ec-ab274ab20d5e.png)



# Notes: 
- Trello card link: https://trello.com/c/hSfaTcVA/156-call-outcomes-view-changes