### PR TITLE
Fix new lines rendering for case notes

### DIFF
--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -223,3 +223,7 @@ label[for="HelpNeeded-3"] {
   content: "*";
   color: red;
 }
+
+.wrap-white-space {
+  white-space: pre-wrap;
+}

--- a/public/app.css
+++ b/public/app.css
@@ -4358,3 +4358,6 @@ label[for="HelpNeeded-3"] {
 .mandatoryQuestion::after {
   content: "*";
   color: red; }
+
+.wrap-white-space {
+  white-space: pre-wrap; }

--- a/views/partials/case-notes-history.njk
+++ b/views/partials/case-notes-history.njk
@@ -9,6 +9,6 @@
     </div>
     {% endfor %}
 {% else %}
-     <p class="lbh-body-m">{{query.CaseNotes}}</p>
+     <p class="wrap-white-space lbh-body-m">{{query.CaseNotes}}</p>
 {% endif %}
 


### PR DESCRIPTION
Wrapping the text notes so that it's not one long text.
No markup, just displays new lines where they exist

before
<img width="535" alt="image" src="https://user-images.githubusercontent.com/54268893/102113100-86737d00-3e30-11eb-983d-280427d620d8.png">

after
<img width="528" alt="image" src="https://user-images.githubusercontent.com/54268893/102112946-5a57fc00-3e30-11eb-8751-b6cf2fa9df10.png">

https://trello.com/c/tn1n5Tug/192-case-note-styling