### PR TITLE
Separate the notes with grey background

### DIFF
--- a/controllers/help-requests/help_requests.controller.js
+++ b/controllers/help-requests/help_requests.controller.js
@@ -112,11 +112,13 @@ const handleHelpRequestUpdate = async (query, userName) => {
 };
 const handleCallCreation = async (query, userName) => {
   try {
-    await HelpRequestCallService.createHelpRequestCall(query, userName).then(result => {
-      if (result.isError === true) {
-        return true;
+    await HelpRequestCallService.createHelpRequestCall(query, userName).then(
+      result => {
+        if (result.isError === true) {
+          return true;
+        }
       }
-    });
+    );
   } catch (err) {
     console.log(err);
   }
@@ -241,6 +243,12 @@ module.exports = {
           res.locals.hasupdated = req.query.hasupdated;
           if (result.CaseNotes && notesHelper.isJSON(result.CaseNotes)) {
             result.jsonCaseNotes = JSON.parse(result.CaseNotes);
+          } else {
+            var separators = ["------\r\n\r\n\r\n", "------\n\n\n"];
+            result.nonJsonCaseNotes = result.CaseNotes.split(
+              new RegExp(separators.join("|"), "g")
+            );
+            console.log(result.nonJsonCaseNotes);
           }
           if (result.HelpRequestCalls) {
             result.HelpRequestCalls.forEach(x => {
@@ -476,7 +484,8 @@ module.exports = {
             // keep the original record and update only case notes and callback
             let updateRequest = originalRecord;
             updateRequest.NewCaseNote = query.NewCaseNote;
-            updateRequest.initialCallBack = query.InitialCallbackCompleted == 'true' ? true : false;
+            updateRequest.initialCallBack =
+              query.InitialCallbackCompleted == "true" ? true : false;
             updateRequest.callback_required = query.callback_required;
             handleUpdate(req, res, updateRequest, userName);
           }

--- a/views/partials/case-notes-history.njk
+++ b/views/partials/case-notes-history.njk
@@ -3,12 +3,16 @@
 
 {% if query.jsonCaseNotes %}
     {% for item in query.jsonCaseNotes %}
-    <div class="note-container">
-    <span class="lbh-body-m note-header">{{item.author}}</span> <span class="lbh-body-m note-date">{{item.noteDate}}</span>
-    <p class="lbh-body-m">{{item.note}}</p>
-    </div>
+        <div class="note-container">
+            <span class="lbh-body-m note-header">{{item.author}}</span> <span class="lbh-body-m note-date">{{item.noteDate}}</span>
+            <p class="lbh-body-m">{{item.note}}</p>
+        </div>
     {% endfor %}
 {% else %}
-     <p class="wrap-white-space lbh-body-m">{{query.CaseNotes}}</p>
+    {% for item in query.nonJsonCaseNotes %}
+        <div class="note-container">
+            <p class="wrap-white-space lbh-body-m">{{item}}</p>
+        </div>
+    {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Add grey background to each old style case note so that they're more easily told apart 

before
<img width="679" alt="image" src="https://user-images.githubusercontent.com/54268893/102252405-f7349b00-3efd-11eb-99ed-97cb5ece09a1.png">


after
<img width="677" alt="image" src="https://user-images.githubusercontent.com/54268893/102252378-ec7a0600-3efd-11eb-9a38-5c4051cfa9d8.png">

https://trello.com/c/tn1n5Tug/192-case-note-styling