### PR TITLE
Redirect notification banner on old version of Here To Help tool

### DIFF
--- a/SAMPLE.env
+++ b/SAMPLE.env
@@ -43,3 +43,6 @@ AUTHORISED_ADMIN_GROUP =
 
 # Hackney frontdoor snapshot service url
 SNAPSHOT_URL =
+
+# Redirect url to new front end
+NEW_FRONT_END_REDIRECTION_URL = 

--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -20,6 +20,7 @@
 @import "node_modules/lbh-frontend/lbh/components/lbh-tag/tag";
 @import "node_modules/lbh-frontend/lbh/components/lbh-tabs/tabs";
 @import "node_modules/lbh-frontend/lbh/components/lbh-textarea/textarea";
+@import "node_modules/govuk-frontend/govuk/components/notification-banner/notification-banner";
 @import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap");
 
 html.lbh-template > body.lbh-template__body * {

--- a/config/index.js
+++ b/config/index.js
@@ -33,6 +33,7 @@ module.exports = {
     authorised_admin_group: process.env.AUTHORISED_ADMIN_GROUP,
     token_name: process.env.TOKEN_NAME,
     hackney_jwt_secret: process.env.HACKNEY_JWT_SECRET,
+    new_front_end_redirection_url: process.env.NEW_FRONT_END_REDIRECTION_URL,
 
     winston: {
         console: {

--- a/loaders/express.js
+++ b/loaders/express.js
@@ -65,6 +65,7 @@ module.exports = {
         .addGlobal('addresses_api_url', config.addresses_api_url)
         .addGlobal('addresses_api_key',  config.addresses_api_key)
         .addGlobal('addresses_api_token',  config.addresses_api_token)
+        .addGlobal('new_front_end_redirection_url', config.new_front_end_redirection_url)
         .addGlobal('GA_UA', config.ga_ua);
 
         app.set('views', path.join(__dirname, 'views'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -3544,6 +3544,12 @@
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
     },
+    "env-paths": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+      "dev": true
+    },
     "env-variable": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
@@ -5110,6 +5116,15 @@
         "universalify": "^0.1.0"
       }
     },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
@@ -6347,9 +6362,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.6.0.tgz",
-      "integrity": "sha512-wTxufdY8vFvKJ2EmmQKmarrQ7n30kzg+vvqgGib2dawl7c5Wst8dffkEJQpy9Zs99TE/yEEFgj0VUO4GRUO22A=="
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.11.0.tgz",
+      "integrity": "sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg=="
     },
     "graceful-fs": {
       "version": "4.2.3",
@@ -7168,6 +7183,131 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "node-gyp": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+          "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+          "dev": true,
+          "requires": {
+            "fstream": "^1.0.0",
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "osenv": "0",
+            "request": "^2.87.0",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^2.0.0",
+            "which": "1"
+          }
+        },
+        "node-sass": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
+          "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
+          "dev": true,
+          "requires": {
+            "async-foreach": "^0.1.3",
+            "chalk": "^1.1.1",
+            "cross-spawn": "^3.0.0",
+            "gaze": "^1.0.0",
+            "get-stdin": "^4.0.1",
+            "glob": "^7.0.3",
+            "in-publish": "^2.0.0",
+            "lodash": "^4.17.15",
+            "meow": "^3.7.0",
+            "mkdirp": "^0.5.1",
+            "nan": "^2.13.2",
+            "node-gyp": "^3.8.0",
+            "npmlog": "^4.0.0",
+            "request": "^2.88.0",
+            "sass-graph": "2.2.5",
+            "stdout-stream": "^1.4.0",
+            "true-case-path": "^1.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -7176,6 +7316,29 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "tar": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+          "dev": true,
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.12",
+            "inherits": "2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
         }
       }
     },
@@ -9345,13 +9508,12 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^4.0.0"
       }
     },
     "make-dir": {
@@ -9748,6 +9910,25 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      }
     },
     "mississippi": {
       "version": "3.0.0",
@@ -10168,48 +10349,49 @@
       }
     },
     "node-gyp": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
+      "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
       "dev": true,
       "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.3",
+        "nopt": "^5.0.0",
+        "npmlog": "^4.1.2",
+        "request": "^2.88.2",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.2",
+        "tar": "^6.0.2",
+        "which": "^2.0.2"
       },
       "dependencies": {
         "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+          "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
           "dev": true,
           "requires": {
             "abbrev": "1"
           }
         },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "lru-cache": "^6.0.0"
           }
         },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -10288,26 +10470,25 @@
       "dev": true
     },
     "node-sass": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.0.tgz",
-      "integrity": "sha512-AxqU+DFpk0lEz95sI6jO0hU0Rwyw7BXVEv6o9OItoXLyeygPeaSpiV4rwQb10JiTghHaa0gZeD21sz+OsQluaw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-5.0.0.tgz",
+      "integrity": "sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
-        "cross-spawn": "^3.0.0",
+        "cross-spawn": "^7.0.3",
         "gaze": "^1.0.0",
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
-        "in-publish": "^2.0.0",
         "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
-        "node-gyp": "^3.8.0",
+        "node-gyp": "^7.1.0",
         "npmlog": "^4.0.0",
         "request": "^2.88.0",
-        "sass-graph": "^2.2.4",
+        "sass-graph": "2.2.5",
         "stdout-stream": "^1.4.0",
         "true-case-path": "^1.0.2"
       },
@@ -10338,14 +10519,36 @@
           }
         },
         "cross-spawn": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -10361,6 +10564,15 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -13693,73 +13905,15 @@
       "dev": true
     },
     "sass-graph": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
+      "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
         "lodash": "^4.0.0",
         "scss-tokenizer": "^0.2.3",
-        "yargs": "^7.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "yargs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
-          }
-        }
+        "yargs": "^13.3.2"
       }
     },
     "sass-lint": {
@@ -15598,14 +15752,31 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
+      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
       "dev": true,
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
       }
     },
     "term-size": {
@@ -17847,9 +18018,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-validator": "^6.4.0",
-    "govuk-frontend": "^3.6.0",
+    "govuk-frontend": "^3.11.0",
     "gulp-env": "^0.4.0",
     "helmet": "^3.22.0",
     "jsonwebtoken": "^8.5.1",
@@ -78,7 +78,7 @@
     "marked": "^0.8.0",
     "merge-stream": "^2.0.0",
     "mocha": "^8.1.1",
-    "node-sass": "^4.13.1",
+    "node-sass": "^5.0.0",
     "nodemon": "^2.0.4",
     "oldie": "^1.3.0",
     "outdent": "^0.7.0",
@@ -90,10 +90,10 @@
     "sass-color-helpers": "^2.1.1",
     "shuffle-seed": "^1.1.6",
     "standard": "^13.1.0",
+    "start-server-and-test": "^1.11.0",
     "vinyl-named-with-path": "^1.0.0",
     "vinyl-paths": "^2.1.0",
     "webpack-stream": "^5.2.1",
-    "yargs": "^13.2.2",
-    "start-server-and-test": "^1.11.0"
+    "yargs": "^13.2.2"
   }
 }

--- a/public/app.css
+++ b/public/app.css
@@ -1,23 +1,24 @@
 @import url("https://fonts.googleapis.com/css2?family=Open+Sans:300,400,600,700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap");
 .govuk-link {
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale; }
 
 /*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */
+/* stylelint-disable-line scss/comment-no-loud  */
 @font-face {
   font-family: "GDS Transport";
-  src: url("/assets/fonts/light-94a07e06a1-v2.woff2") format("woff2"), url("/assets/fonts/light-f591b13f7d-v2.woff") format("woff");
-  font-weight: normal;
   font-style: normal;
+  font-weight: normal;
+  src: url("/assets/fonts/light-94a07e06a1-v2.woff2") format("woff2"), url("/assets/fonts/light-f591b13f7d-v2.woff") format("woff");
   font-display: fallback; }
 
 @font-face {
   font-family: "GDS Transport";
-  src: url("/assets/fonts/bold-b542beb274-v2.woff2") format("woff2"), url("/assets/fonts/bold-affa96571d-v2.woff") format("woff");
-  font-weight: bold;
   font-style: normal;
+  font-weight: bold;
+  src: url("/assets/fonts/bold-b542beb274-v2.woff2") format("woff2"), url("/assets/fonts/bold-affa96571d-v2.woff") format("woff");
   font-display: fallback; }
   @media print {
     .govuk-link {
@@ -45,9 +46,9 @@
 .govuk-link.\:focus {
     color: #0b0c0c; }
   @media print {
-    .govuk-link[href^="/"]::after, .govuk-link[href^="http://"]::after, .govuk-link[href^="https://"]::after,
-.govuk-link[href^="http.\://"]::after,
-.govuk-link[href^="https.\://"]::after {
+    .govuk-link[href^="/"]:after, .govuk-link[href^="http://"]:after, .govuk-link[href^="https://"]:after,
+.govuk-link[href^="http.\://"]:after,
+.govuk-link[href^="https.\://"]:after {
       content: " (" attr(href) ")";
       font-size: 90%;
       word-wrap: break-word; } }
@@ -57,7 +58,7 @@
 .govuk-link--muted.\:visited,
 .govuk-link--muted.\:hover,
 .govuk-link--muted.\:active {
-  color: #626a6e; }
+  color: #505a5f; }
 
 .govuk-link--muted:focus,
 .govuk-link--muted.\:focus {
@@ -100,7 +101,7 @@
   color: #0b0c0c; }
 
 .govuk-list {
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -152,6 +153,12 @@
     .govuk-list--number > li {
       margin-bottom: 5px; } }
 
+.govuk-list--spaced > li {
+  margin-bottom: 10px; }
+  @media (min-width: 40.0625em) {
+    .govuk-list--spaced > li {
+      margin-bottom: 15px; } }
+
 .govuk-template {
   background-color: #f3f2f1;
   -webkit-text-size-adjust: 100%;
@@ -168,7 +175,7 @@
 
 .govuk-heading-xl {
   color: #0b0c0c;
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -199,7 +206,7 @@
 
 .govuk-heading-l {
   color: #0b0c0c;
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -230,7 +237,7 @@
 
 .govuk-heading-m {
   color: #0b0c0c;
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -261,7 +268,7 @@
 
 .govuk-heading-s {
   color: #0b0c0c;
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -291,7 +298,7 @@
       margin-bottom: 20px; } }
 
 .govuk-caption-xl {
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -300,7 +307,7 @@
   line-height: 1.11111;
   display: block;
   margin-bottom: 5px;
-  color: #626a6e; }
+  color: #505a5f; }
   @media print {
     .govuk-caption-xl {
       font-family: sans-serif; } }
@@ -315,7 +322,7 @@
       line-height: 1.15; } }
 
 .govuk-caption-l {
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -324,7 +331,7 @@
   line-height: 1.11111;
   display: block;
   margin-bottom: 5px;
-  color: #626a6e; }
+  color: #505a5f; }
   @media print {
     .govuk-caption-l {
       font-family: sans-serif; } }
@@ -342,7 +349,7 @@
       margin-bottom: 0; } }
 
 .govuk-caption-m {
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -350,7 +357,7 @@
   font-size: 1rem;
   line-height: 1.25;
   display: block;
-  color: #626a6e; }
+  color: #505a5f; }
   @media print {
     .govuk-caption-m {
       font-family: sans-serif; } }
@@ -366,7 +373,7 @@
 
 .govuk-body-l, .govuk-body-lead {
   color: #0b0c0c;
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -396,7 +403,7 @@
 
 .govuk-body-m, .govuk-body {
   color: #0b0c0c;
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -426,7 +433,7 @@
 
 .govuk-body-s {
   color: #0b0c0c;
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -456,7 +463,7 @@
 
 .govuk-body-xs {
   color: #0b0c0c;
-  font-family: "GDS Transport", Arial, sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -669,9 +676,9 @@ video {
 .lbh-link.\:focus {
     color: #0b0c0c; }
   @media print {
-    .lbh-link[href^="/"]::after, .lbh-link[href^="http://"]::after, .lbh-link[href^="https://"]::after,
-.lbh-link[href^="http.\://"]::after,
-.lbh-link[href^="https.\://"]::after {
+    .lbh-link[href^="/"]:after, .lbh-link[href^="http://"]:after, .lbh-link[href^="https://"]:after,
+.lbh-link[href^="http.\://"]:after,
+.lbh-link[href^="https.\://"]:after {
       content: " (" attr(href) ")";
       font-size: 90%;
       word-wrap: break-word; } }
@@ -681,7 +688,7 @@ video {
 .lbh-link--muted.\:visited,
 .lbh-link--muted.\:hover,
 .lbh-link--muted.\:active {
-  color: #626a6e; }
+  color: #505a5f; }
 
 .lbh-link--muted:focus,
 .lbh-link--muted.\:focus {
@@ -1020,6 +1027,53 @@ strong {
 html {
   scroll-behavior: smooth; }
 
+.govuk-button-group {
+  margin-bottom: 5px;
+  display: flex;
+  flex-direction: column;
+  align-items: center; }
+  @media (min-width: 40.0625em) {
+    .govuk-button-group {
+      margin-bottom: 15px; } }
+  .govuk-button-group .govuk-link {
+    font-family: "Open Sans";
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 400;
+    font-size: 16px;
+    font-size: 1rem;
+    line-height: 1.1875;
+    display: inline-block;
+    max-width: 100%;
+    margin-top: 5px;
+    margin-bottom: 20px;
+    text-align: center; }
+    @media print {
+      .govuk-button-group .govuk-link {
+        font-family: sans-serif; } }
+    @media (min-width: 40.0625em) {
+      .govuk-button-group .govuk-link {
+        font-size: 19px;
+        font-size: 1.1875rem;
+        line-height: 1; } }
+    @media print {
+      .govuk-button-group .govuk-link {
+        font-size: 14pt;
+        line-height: 19px; } }
+  .govuk-button-group .govuk-button {
+    margin-bottom: 17px; }
+  @media (min-width: 40.0625em) {
+    .govuk-button-group {
+      margin-right: -15px;
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-items: baseline; }
+      .govuk-button-group .govuk-button,
+      .govuk-button-group .govuk-link {
+        margin-right: 15px; }
+      .govuk-button-group .govuk-link {
+        text-align: left; } }
+
 .govuk-form-group {
   margin-bottom: 20px; }
   .govuk-form-group:after {
@@ -1253,8 +1307,27 @@ html {
   padding-bottom: 15px; }
 
 .govuk-accordion__section-heading {
+  font-family: "Open Sans";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  font-size: 1.125rem;
+  line-height: 1.11111;
   margin-top: 0;
   margin-bottom: 0; }
+  @media print {
+    .govuk-accordion__section-heading {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-accordion__section-heading {
+      font-size: 24px;
+      font-size: 1.5rem;
+      line-height: 1.25; } }
+  @media print {
+    .govuk-accordion__section-heading {
+      font-size: 18pt;
+      line-height: 1.15; } }
 
 .govuk-accordion__section-button {
   font-family: "Open Sans";
@@ -1556,28 +1629,36 @@ html {
         color: #000000; } }
 
 .govuk-back-link[href] {
-  border-bottom: 1px solid #0b0c0c;
-  text-decoration: none; }
+  text-decoration: underline; }
   .govuk-back-link[href]:focus,
 .govuk-back-link[href].\:focus {
-    border-bottom-color: transparent; }
+    text-decoration: none; }
+    .govuk-back-link[href]:focus:before,
+.govuk-back-link[href].\:focus:before {
+      border-color: #0b0c0c; }
 
 .govuk-back-link:before {
-  display: block;
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-color: transparent;
-  -webkit-clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
-  clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
-  border-width: 5px 6px 5px 0;
-  border-right-color: inherit;
   content: "";
+  display: block;
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 0;
-  margin: auto; }
+  left: 3px;
+  width: 7px;
+  height: 7px;
+  margin: auto 0;
+  transform: rotate(225deg);
+  border: solid;
+  border-width: 1px 1px 0 0;
+  border-color: #505a5f; }
+
+.govuk-back-link:after {
+  content: "";
+  position: absolute;
+  top: -14px;
+  right: 0;
+  bottom: -14px;
+  left: 0; }
 
 .lbh-back-link {
   border: 0; }
@@ -1713,6 +1794,8 @@ html {
   position: relative;
   width: 100%;
   margin-top: 0;
+  margin-right: 0;
+  margin-left: 0;
   margin-bottom: 22px;
   padding: 8px 10px 7px;
   border: 2px solid transparent;
@@ -1769,7 +1852,7 @@ html {
     color: #0b0c0c;
     background-color: #ffdd00;
     box-shadow: 0 2px 0 #0b0c0c; }
-  .govuk-button::before {
+  .govuk-button:before {
     content: "";
     display: block;
     position: absolute;
@@ -1778,8 +1861,8 @@ html {
     bottom: -4px;
     left: -2px;
     background: transparent; }
-  .govuk-button:active::before,
-.govuk-button.\:active::before {
+  .govuk-button:active:before,
+.govuk-button.\:active:before {
     top: -4px; }
 
 .govuk-button--disabled,
@@ -1961,7 +2044,7 @@ html {
   line-height: 1.25;
   display: block;
   margin-bottom: 15px;
-  color: #626a6e; }
+  color: #505a5f; }
   @media print {
     .govuk-hint {
       font-family: sans-serif; } }
@@ -1983,7 +2066,6 @@ html {
 .govuk-fieldset__legend.\:not\(.govuk-fieldset__legend--m\).\:not\(.govuk-fieldset__legend--l\).\:not\(.govuk-fieldset__legend--xl\) + .govuk-hint {
   margin-bottom: 10px; }
 
-.govuk-fieldset__legend + .govuk-hint,
 .govuk-fieldset__legend + .govuk-hint {
   margin-top: -5px; }
 
@@ -2473,7 +2555,7 @@ x.\:-moz-any-link {
   cursor: pointer;
   touch-action: manipulation; }
 
-.govuk-checkboxes__label::before {
+.govuk-checkboxes__label:before {
   content: "";
   box-sizing: border-box;
   position: absolute;
@@ -2484,13 +2566,14 @@ x.\:-moz-any-link {
   border: 2px solid currentColor;
   background: transparent; }
 
-.govuk-checkboxes__label::after {
+.govuk-checkboxes__label:after {
   content: "";
+  box-sizing: border-box;
   position: absolute;
   top: 11px;
   left: 9px;
-  width: 18px;
-  height: 7px;
+  width: 23px;
+  height: 12px;
   transform: rotate(-45deg);
   border: solid;
   border-width: 0 0 5px 5px;
@@ -2503,13 +2586,13 @@ x.\:-moz-any-link {
   padding-right: 15px;
   padding-left: 15px; }
 
-.govuk-checkboxes__input:focus + .govuk-checkboxes__label::before,
-.govuk-checkboxes__input.\:focus + .govuk-checkboxes__label::before {
+.govuk-checkboxes__input:focus + .govuk-checkboxes__label:before,
+.govuk-checkboxes__input.\:focus + .govuk-checkboxes__label:before {
   border-width: 4px;
   box-shadow: 0 0 0 3px #ffdd00; }
 
-.govuk-checkboxes__input:checked + .govuk-checkboxes__label::after,
-.govuk-checkboxes__input.\:checked + .govuk-checkboxes__label::after {
+.govuk-checkboxes__input:checked + .govuk-checkboxes__label:after,
+.govuk-checkboxes__input.\:checked + .govuk-checkboxes__label:after {
   opacity: 1; }
 
 .govuk-checkboxes__input:disabled,
@@ -2557,16 +2640,16 @@ x.\:-moz-any-link {
     .govuk-checkboxes--small .govuk-checkboxes__label {
       padding: 11px 15px 10px 1px; } }
 
-.govuk-checkboxes--small .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__label:before {
   top: 8px;
   width: 24px;
   height: 24px; }
 
-.govuk-checkboxes--small .govuk-checkboxes__label::after {
+.govuk-checkboxes--small .govuk-checkboxes__label:after {
   top: 15px;
   left: 6px;
-  width: 9px;
-  height: 3.5px;
+  width: 12px;
+  height: 6.5px;
   border-width: 0 0 3px 3px; }
 
 .govuk-checkboxes--small .govuk-checkboxes__hint {
@@ -2578,20 +2661,20 @@ x.\:-moz-any-link {
   padding-left: 20px;
   clear: both; }
 
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before,
-.govuk-checkboxes--small .govuk-checkboxes__item.\:hover .govuk-checkboxes__input.\:not\(:disabled) + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label:before,
+.govuk-checkboxes--small .govuk-checkboxes__item.\:hover .govuk-checkboxes__input.\:not\(:disabled) + .govuk-checkboxes__label:before {
   box-shadow: 0 0 0 10px #b1b4b6; }
 
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before,
-.govuk-checkboxes--small .govuk-checkboxes__item.\:hover .govuk-checkboxes__input.\:focus + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label:before,
+.govuk-checkboxes--small .govuk-checkboxes__item.\:hover .govuk-checkboxes__input.\:focus + .govuk-checkboxes__label:before {
   box-shadow: 0 0 0 3px #ffdd00, 0 0 0 10px #b1b4b6; }
 
 @media (hover: none), (pointer: coarse) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before,
-.govuk-checkboxes--small .govuk-checkboxes__item.\:hover .govuk-checkboxes__input.\:not\(:disabled) + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label:before,
+.govuk-checkboxes--small .govuk-checkboxes__item.\:hover .govuk-checkboxes__input.\:not\(:disabled) + .govuk-checkboxes__label:before {
     box-shadow: initial; }
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before,
-.govuk-checkboxes--small .govuk-checkboxes__item.\:hover .govuk-checkboxes__input.\:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label:before,
+.govuk-checkboxes--small .govuk-checkboxes__item.\:hover .govuk-checkboxes__input.\:focus + .govuk-checkboxes__label:before {
     box-shadow: 0 0 0 3px #ffdd00; } }
 
 .lbh-checkboxes {
@@ -2718,11 +2801,10 @@ x.\:-moz-any-link {
   -moz-appearance: textfield; }
 
 .govuk-input--error {
-  border: 4px solid #d4351c; }
+  border: 2px solid #d4351c; }
   .govuk-input--error:focus,
 .govuk-input--error.\:focus {
-    border-color: #0b0c0c;
-    box-shadow: none; }
+    border-color: #0b0c0c; }
 
 .govuk-input--width-30 {
   max-width: 59ex; }
@@ -2744,6 +2826,83 @@ x.\:-moz-any-link {
 
 .govuk-input--width-2 {
   max-width: 5.4ex; }
+
+.govuk-input__wrapper {
+  display: flex; }
+  .govuk-input__wrapper .govuk-input {
+    flex: 0 1 auto; }
+  .govuk-input__wrapper .govuk-input:focus,
+.govuk-input__wrapper .govuk-input.\:focus {
+    z-index: 1; }
+  @media (max-width: 19.99em) {
+    .govuk-input__wrapper {
+      display: block; }
+      .govuk-input__wrapper .govuk-input {
+        max-width: 100%; } }
+
+.govuk-input__prefix,
+.govuk-input__suffix {
+  font-family: "Open Sans";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
+  box-sizing: border-box;
+  display: inline-block;
+  min-width: 40px;
+  min-width: 2.5rem;
+  height: 40px;
+  height: 2.5rem;
+  padding: 5px;
+  border: 2px solid #0b0c0c;
+  background-color: #f3f2f1;
+  text-align: center;
+  white-space: nowrap;
+  cursor: default;
+  flex: 0 0 auto; }
+  @media print {
+    .govuk-input__prefix,
+    .govuk-input__suffix {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-input__prefix,
+    .govuk-input__suffix {
+      font-size: 19px;
+      font-size: 1.1875rem;
+      line-height: 1.31579; } }
+  @media print {
+    .govuk-input__prefix,
+    .govuk-input__suffix {
+      font-size: 14pt;
+      line-height: 1.15; } }
+  @media (max-width: 40.0525em) {
+    .govuk-input__prefix,
+    .govuk-input__suffix {
+      line-height: 1.6; } }
+  @media (max-width: 19.99em) {
+    .govuk-input__prefix,
+    .govuk-input__suffix {
+      display: block;
+      height: 100%;
+      white-space: normal; } }
+
+@media (max-width: 19.99em) {
+  .govuk-input__prefix {
+    border-bottom: 0; } }
+
+@media (min-width: 20em) {
+  .govuk-input__prefix {
+    border-right: 0; } }
+
+@media (max-width: 19.99em) {
+  .govuk-input__suffix {
+    border-top: 0; } }
+
+@media (min-width: 20em) {
+  .govuk-input__suffix {
+    border-left: 0; } }
 
 .lbh-input {
   font-family: "Open Sans";
@@ -2924,13 +3083,13 @@ x.\:-moz-any-link {
   margin-bottom: 0; }
 
 .govuk-error-summary__list a {
-  font-weight: 700; }
-  .govuk-error-summary__list a:link, .govuk-error-summary__list a:visited, .govuk-error-summary__list a:hover, .govuk-error-summary__list a:active,
-.govuk-error-summary__list a.\:link,
-.govuk-error-summary__list a.\:visited,
-.govuk-error-summary__list a.\:hover,
-.govuk-error-summary__list a.\:active {
-    color: #d4351c; }
+  font-weight: 700;
+  font-family: "Open Sans";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale; }
+  @media print {
+    .govuk-error-summary__list a {
+      font-family: sans-serif; } }
   .govuk-error-summary__list a:focus,
 .govuk-error-summary__list a.\:focus {
     outline: 3px solid transparent;
@@ -2938,6 +3097,19 @@ x.\:-moz-any-link {
     background-color: #ffdd00;
     box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
     text-decoration: none; }
+  .govuk-error-summary__list a:link, .govuk-error-summary__list a:visited,
+.govuk-error-summary__list a.\:link,
+.govuk-error-summary__list a.\:visited {
+    color: #d4351c; }
+  .govuk-error-summary__list a:hover,
+.govuk-error-summary__list a.\:hover {
+    color: #942514; }
+  .govuk-error-summary__list a:active,
+.govuk-error-summary__list a.\:active {
+    color: #d4351c; }
+  .govuk-error-summary__list a:focus,
+.govuk-error-summary__list a.\:focus {
+    color: #0b0c0c; }
 
 .lbh-error-summary {
   margin-bottom: 0;
@@ -3290,6 +3462,11 @@ x.\:-moz-any-link {
 .govuk-panel--confirmation {
   color: #ffffff;
   background: #00703c; }
+  @media print {
+    .govuk-panel--confirmation {
+      border-color: currentColor;
+      color: #000000;
+      background: none; } }
 
 .govuk-panel__title {
   margin-top: 0;
@@ -3426,7 +3603,7 @@ x.\:-moz-any-link {
   cursor: pointer;
   touch-action: manipulation; }
 
-.govuk-radios__label::before {
+.govuk-radios__label:before {
   content: "";
   box-sizing: border-box;
   position: absolute;
@@ -3438,7 +3615,7 @@ x.\:-moz-any-link {
   border-radius: 50%;
   background: transparent; }
 
-.govuk-radios__label::after {
+.govuk-radios__label:after {
   content: "";
   position: absolute;
   top: 10px;
@@ -3455,13 +3632,13 @@ x.\:-moz-any-link {
   padding-right: 15px;
   padding-left: 15px; }
 
-.govuk-radios__input:focus + .govuk-radios__label::before,
-.govuk-radios__input.\:focus + .govuk-radios__label::before {
+.govuk-radios__input:focus + .govuk-radios__label:before,
+.govuk-radios__input.\:focus + .govuk-radios__label:before {
   border-width: 4px;
   box-shadow: 0 0 0 4px #ffdd00; }
 
-.govuk-radios__input:checked + .govuk-radios__label::after,
-.govuk-radios__input.\:checked + .govuk-radios__label::after {
+.govuk-radios__input:checked + .govuk-radios__label:after,
+.govuk-radios__input.\:checked + .govuk-radios__label:after {
   opacity: 1; }
 
 .govuk-radios__input:disabled,
@@ -3551,12 +3728,12 @@ x.\:-moz-any-link {
     .govuk-radios--small .govuk-radios__label {
       padding: 11px 15px 10px 1px; } }
 
-.govuk-radios--small .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__label:before {
   top: 8px;
   width: 24px;
   height: 24px; }
 
-.govuk-radios--small .govuk-radios__label::after {
+.govuk-radios--small .govuk-radios__label:after {
   top: 15px;
   left: 7px;
   border-width: 5px; }
@@ -3575,20 +3752,20 @@ x.\:-moz-any-link {
   width: 24px;
   margin-bottom: 5px; }
 
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before,
-.govuk-radios--small .govuk-radios__item.\:hover .govuk-radios__input.\:not\(:disabled) + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label:before,
+.govuk-radios--small .govuk-radios__item.\:hover .govuk-radios__input.\:not\(:disabled) + .govuk-radios__label:before {
   box-shadow: 0 0 0 10px #b1b4b6; }
 
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before,
-.govuk-radios--small .govuk-radios__item.\:hover .govuk-radios__input.\:focus + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label:before,
+.govuk-radios--small .govuk-radios__item.\:hover .govuk-radios__input.\:focus + .govuk-radios__label:before {
   box-shadow: 0 0 0 4px #ffdd00, 0 0 0 10px #b1b4b6; }
 
 @media (hover: none), (pointer: coarse) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before,
-.govuk-radios--small .govuk-radios__item.\:hover .govuk-radios__input.\:not\(:disabled) + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label:before,
+.govuk-radios--small .govuk-radios__item.\:hover .govuk-radios__input.\:not\(:disabled) + .govuk-radios__label:before {
     box-shadow: initial; }
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before,
-.govuk-radios--small .govuk-radios__item.\:hover .govuk-radios__input.\:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label:before,
+.govuk-radios--small .govuk-radios__item.\:hover .govuk-radios__input.\:focus + .govuk-radios__label:before {
     box-shadow: 0 0 0 4px #ffdd00; } }
 
 .lbh-radios .govuk-label {
@@ -3686,11 +3863,10 @@ x.\:-moz-any-link {
   background-color: #1d70b8; }
 
 .govuk-select--error {
-  border: 4px solid #d4351c; }
+  border: 2px solid #d4351c; }
   .govuk-select--error:focus,
 .govuk-select--error.\:focus {
-    border-color: #0b0c0c;
-    box-shadow: none; }
+    border-color: #0b0c0c; }
 
 .lbh-select {
   margin-top: 6px;
@@ -3766,6 +3942,7 @@ x.\:-moz-any-link {
   .govuk-skip-link:focus,
 .govuk-skip-link.\:focus {
     outline: 3px solid #ffdd00;
+    outline-offset: 0;
     background-color: #ffdd00; }
 
 .lbh-form-group {
@@ -3842,6 +4019,93 @@ x.\:-moz-any-link {
   display: table-caption;
   text-align: left; }
 
+.govuk-table__caption--xl {
+  font-family: "Open Sans";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 32px;
+  font-size: 2rem;
+  line-height: 1.09375;
+  margin-bottom: 15px; }
+  @media print {
+    .govuk-table__caption--xl {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-table__caption--xl {
+      font-size: 48px;
+      font-size: 3rem;
+      line-height: 1.04167; } }
+  @media print {
+    .govuk-table__caption--xl {
+      font-size: 32pt;
+      line-height: 1.15; } }
+
+.govuk-table__caption--l {
+  font-family: "Open Sans";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 24px;
+  font-size: 1.5rem;
+  line-height: 1.04167;
+  margin-bottom: 15px; }
+  @media print {
+    .govuk-table__caption--l {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-table__caption--l {
+      font-size: 36px;
+      font-size: 2.25rem;
+      line-height: 1.11111; } }
+  @media print {
+    .govuk-table__caption--l {
+      font-size: 24pt;
+      line-height: 1.05; } }
+
+.govuk-table__caption--m {
+  font-family: "Open Sans";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 18px;
+  font-size: 1.125rem;
+  line-height: 1.11111;
+  margin-bottom: 15px; }
+  @media print {
+    .govuk-table__caption--m {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-table__caption--m {
+      font-size: 24px;
+      font-size: 1.5rem;
+      line-height: 1.25; } }
+  @media print {
+    .govuk-table__caption--m {
+      font-size: 18pt;
+      line-height: 1.15; } }
+
+.govuk-table__caption--s {
+  font-family: "Open Sans";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25; }
+  @media print {
+    .govuk-table__caption--s {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-table__caption--s {
+      font-size: 19px;
+      font-size: 1.1875rem;
+      line-height: 1.31579; } }
+  @media print {
+    .govuk-table__caption--s {
+      font-size: 14pt;
+      line-height: 1.15; } }
+
 .lbh-table {
   font-family: "Open Sans";
   -webkit-font-smoothing: antialiased;
@@ -3903,11 +4167,11 @@ x.\:-moz-any-link {
       line-height: 1; } }
 
 .govuk-tag--inactive {
-  background-color: #626a6e; }
+  background-color: #505a5f; }
 
 .govuk-tag--grey {
-  color: #454a4d;
-  background: #eff0f1; }
+  color: #383f43;
+  background: #eeefef; }
 
 .govuk-tag--purple {
   color: #3d2375;
@@ -4029,13 +4293,13 @@ x.\:-moz-any-link {
     .govuk-tabs__list-item {
       font-size: 14pt;
       line-height: 1.15; } }
-  .govuk-tabs__list-item::before {
+  .govuk-tabs__list-item:before {
     color: #0b0c0c;
     content: "\2014 ";
     margin-left: -25px;
     padding-right: 5px; }
     @media print {
-      .govuk-tabs__list-item::before {
+      .govuk-tabs__list-item:before {
         color: #000000; } }
 
 .govuk-tabs__tab {
@@ -4089,7 +4353,7 @@ x.\:-moz-any-link {
     float: left;
     background-color: #f3f2f1;
     text-align: center; }
-    .js-enabled .govuk-tabs__list-item::before {
+    .js-enabled .govuk-tabs__list-item:before {
       content: none; }
   .js-enabled .govuk-tabs__list-item--selected {
     position: relative;
@@ -4123,7 +4387,7 @@ x.\:-moz-any-link {
         color: #000000; } }
 
 @media (min-width: 40.0625em) {
-    .js-enabled .govuk-tabs__tab::after {
+    .js-enabled .govuk-tabs__tab:after {
       content: "";
       position: absolute;
       top: 0;
@@ -4199,15 +4463,162 @@ x.\:-moz-any-link {
     box-shadow: inset 0 0 0 2px; }
 
 .govuk-textarea--error {
-  border: 4px solid #d4351c; }
+  border: 2px solid #d4351c; }
   .govuk-textarea--error:focus,
 .govuk-textarea--error.\:focus {
-    border-color: #0b0c0c;
-    box-shadow: none; }
+    border-color: #0b0c0c; }
 
 .lbh-textarea {
   margin-top: 0;
   margin-bottom: 0; }
+
+.govuk-notification-banner {
+  font-family: "Open Sans";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
+  margin-bottom: 30px;
+  border: 5px solid #1d70b8;
+  background-color: #1d70b8; }
+  @media print {
+    .govuk-notification-banner {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-notification-banner {
+      font-size: 19px;
+      font-size: 1.1875rem;
+      line-height: 1.31579; } }
+  @media print {
+    .govuk-notification-banner {
+      font-size: 14pt;
+      line-height: 1.15; } }
+  @media (min-width: 40.0625em) {
+    .govuk-notification-banner {
+      margin-bottom: 50px; } }
+  .govuk-notification-banner:focus,
+.govuk-notification-banner.\:focus {
+    outline: 3px solid #ffdd00; }
+
+.govuk-notification-banner__header {
+  padding: 2px 15px 5px;
+  border-bottom: 1px solid transparent; }
+  @media (min-width: 40.0625em) {
+    .govuk-notification-banner__header {
+      padding: 2px 20px 5px; } }
+
+.govuk-notification-banner__title {
+  font-family: "Open Sans";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
+  margin: 0;
+  padding: 0;
+  color: #ffffff; }
+  @media print {
+    .govuk-notification-banner__title {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-notification-banner__title {
+      font-size: 19px;
+      font-size: 1.1875rem;
+      line-height: 1.31579; } }
+  @media print {
+    .govuk-notification-banner__title {
+      font-size: 14pt;
+      line-height: 1.15; } }
+
+.govuk-notification-banner__content {
+  color: #0b0c0c;
+  padding: 15px;
+  background-color: #ffffff; }
+  @media print {
+    .govuk-notification-banner__content {
+      color: #000000; } }
+  @media (min-width: 40.0625em) {
+    .govuk-notification-banner__content {
+      padding: 20px; } }
+  .govuk-notification-banner__content > * {
+    box-sizing: border-box;
+    max-width: 605px; }
+  .govuk-notification-banner__content > :last-child,
+.govuk-notification-banner__content > .\:last-child {
+    margin-bottom: 0; }
+
+.govuk-notification-banner__heading {
+  font-family: "Open Sans";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 18px;
+  font-size: 1.125rem;
+  line-height: 1.11111;
+  margin: 0 0 15px 0;
+  padding: 0; }
+  @media print {
+    .govuk-notification-banner__heading {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-notification-banner__heading {
+      font-size: 24px;
+      font-size: 1.5rem;
+      line-height: 1.25; } }
+  @media print {
+    .govuk-notification-banner__heading {
+      font-size: 18pt;
+      line-height: 1.15; } }
+
+.govuk-notification-banner__link {
+  font-family: "Open Sans";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale; }
+  @media print {
+    .govuk-notification-banner__link {
+      font-family: sans-serif; } }
+  .govuk-notification-banner__link:focus,
+.govuk-notification-banner__link.\:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none; }
+  .govuk-notification-banner__link:link,
+.govuk-notification-banner__link.\:link {
+    color: #1d70b8; }
+  .govuk-notification-banner__link:visited,
+.govuk-notification-banner__link.\:visited {
+    color: #1d70b8; }
+  .govuk-notification-banner__link:hover,
+.govuk-notification-banner__link.\:hover {
+    color: #003078; }
+  .govuk-notification-banner__link:active,
+.govuk-notification-banner__link.\:active {
+    color: #0b0c0c; }
+  .govuk-notification-banner__link:focus,
+.govuk-notification-banner__link.\:focus {
+    color: #0b0c0c; }
+
+.govuk-notification-banner--success {
+  border-color: #00703c;
+  background-color: #00703c; }
+  .govuk-notification-banner--success .govuk-notification-banner__link:link, .govuk-notification-banner--success .govuk-notification-banner__link:visited,
+.govuk-notification-banner--success .govuk-notification-banner__link.\:link,
+.govuk-notification-banner--success .govuk-notification-banner__link.\:visited {
+    color: #00703c; }
+  .govuk-notification-banner--success .govuk-notification-banner__link:hover,
+.govuk-notification-banner--success .govuk-notification-banner__link.\:hover {
+    color: #004e2a; }
+  .govuk-notification-banner--success .govuk-notification-banner__link:active,
+.govuk-notification-banner--success .govuk-notification-banner__link.\:active {
+    color: #00703c; }
+  .govuk-notification-banner--success .govuk-notification-banner__link:focus,
+.govuk-notification-banner--success .govuk-notification-banner__link.\:focus {
+    color: #0b0c0c; }
 
 html.lbh-template > body.lbh-template__body * {
   font-family: "Open Sans", sans-serif; }

--- a/public/main.js
+++ b/public/main.js
@@ -150,7 +150,7 @@ eval("(function webpackUniversalModuleDefinition(root, factory) {\n\tif(true)\n\
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-eval("module.exports = __webpack_require__(/*! /Users/maysakanoni/Hackney/coronavirus/coronavirus-get-support-admin/app/assets/js/main.js */\"./app/assets/js/main.js\");\n\n\n//# sourceURL=webpack://Boilerplate/multi_./app/assets/js/main.js?");
+eval("module.exports = __webpack_require__(/*! /Users/ben_dalton/Desktop/Projects/old-front-end/coronavirus-get-support-admin/app/assets/js/main.js */\"./app/assets/js/main.js\");\n\n\n//# sourceURL=webpack://Boilerplate/multi_./app/assets/js/main.js?");
 
 /***/ })
 

--- a/views/layouts/base.njk
+++ b/views/layouts/base.njk
@@ -30,6 +30,7 @@
 
 
 {% block beforeContent %}
+
 <div id="loader_overlay" class="">
   <div id="loader_spinner"></div>
 </div>
@@ -44,7 +45,7 @@
     <p class="govuk-notification-banner__heading">
       Please use the new version of the tool.
       <br/>
-      <a class="govuk-notification-banner__link" href="https://here-to-help.hackney.gov.uk/">View application</a>.
+      <a class="govuk-notification-banner__link" href={{ new_front_end_redirection_url }}>View application</a>.
     </p>
   </div>
 </div>

--- a/views/layouts/base.njk
+++ b/views/layouts/base.njk
@@ -44,7 +44,7 @@
     <p class="govuk-notification-banner__heading">
       Please use the new version of the tool.
       <br/>
-      <a class="govuk-notification-banner__link" href="#">View application</a>.
+      <a class="govuk-notification-banner__link" href="https://here-to-help.hackney.gov.uk/">View application</a>.
     </p>
   </div>
 </div>

--- a/views/layouts/base.njk
+++ b/views/layouts/base.njk
@@ -1,6 +1,21 @@
 {% extends "template.njk" %}
 {% from "lbh-back-to-top/macro.njk" import lbhBackToTop %}
 
+
+{# Import gov uk banner, does not work currently #}
+{# {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% set html %}
+  <p class="govuk-notification-banner__heading">
+    You have 7 days left to send your application.
+    <a class="govuk-notification-banner__link" href="#">View application</a>.
+  </p>
+{% endset %}
+
+{{ govukNotificationBanner({
+  html: html
+}) }} #}
+
 {% block head %}
   {% if GA_UA %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_UA }}"></script>
@@ -24,6 +39,10 @@
     serviceName: "Support for Hackney residents"
   })}}
 {% endblock %}
+
+
+
+
 
 {% block beforeContent %}
 <div id="loader_overlay" class="">

--- a/views/layouts/base.njk
+++ b/views/layouts/base.njk
@@ -1,21 +1,6 @@
 {% extends "template.njk" %}
 {% from "lbh-back-to-top/macro.njk" import lbhBackToTop %}
 
-
-{# Import gov uk banner, does not work currently #}
-{# {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-
-{% set html %}
-  <p class="govuk-notification-banner__heading">
-    You have 7 days left to send your application.
-    <a class="govuk-notification-banner__link" href="#">View application</a>.
-  </p>
-{% endset %}
-
-{{ govukNotificationBanner({
-  html: html
-}) }} #}
-
 {% block head %}
   {% if GA_UA %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_UA }}"></script>
@@ -47,6 +32,22 @@
 {% block beforeContent %}
 <div id="loader_overlay" class="">
   <div id="loader_spinner"></div>
+</div>
+<div class="govuk-width-container">
+<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      Please use the new version of the tool.
+      <br/>
+      <a class="govuk-notification-banner__link" href="#">View application</a>.
+    </p>
+  </div>
+</div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
**What**
- add notification banner which links to new Here To Help tool

**Why** 
- users accessing the old version of the tool will be directed to use the new version

**Screenshot**
![image](https://user-images.githubusercontent.com/70905620/108065518-08ad3700-7056-11eb-9dee-ad697242cadd.png)


**Ticket** 
https://trello.com/c/rTj86NAX/69-redirect-users-to-new-frontend-from-the-old-inh